### PR TITLE
Issue with uploads and Firefox, Issue 69.

### DIFF
--- a/src/libraries/controllers/ApiPhotoController.php
+++ b/src/libraries/controllers/ApiPhotoController.php
@@ -333,7 +333,8 @@ class ApiPhotoController extends BaseController
       return self::created("Photo {$photoId} uploaded successfully", $photo['result']);
     }
 
-    return self::error('File upload failure', false);
+    error_log("File upload failed");
+    return self::error('File upload failure $localFile', false);
   }
 
   /**


### PR DESCRIPTION
Fixed issue where uploads were not working when using Firefox 3.6+, issue seemed related to the $crumb variable not being set when using Firefox.  Adding a call to GetSession to grab the crumb from the Session right before the upload page was generated seemed to fix it.  Some uploads still fail however.
