### PR TITLE
Remove extra param from putUser()

### DIFF
--- a/src/libraries/models/User.php
+++ b/src/libraries/models/User.php
@@ -226,7 +226,7 @@ class User
     */
   private static function create()
   {
-    return getDb()->putUser(getConfig()->get('user')->email, self::getDefaultAttributes());
+    return getDb()->putUser(self::getDefaultAttributes());
   }
 
   /**


### PR DESCRIPTION
For some reason, the create() method had 2 parameters for putUser() instead of 1. Removing the first one (email) fixed the issue. This code now matches the interface, and functions correctly.
