### PR TITLE
Adding missing APC installation step

### DIFF
--- a/documentation/guides/InstallationOSXMacports.markdown
+++ b/documentation/guides/InstallationOSXMacports.markdown
@@ -37,6 +37,7 @@ This guide assumes you have [get it here][Macports installed]. If not you can . 
     sudo port install php5-imagick
     sudo port install php5-oauth
     sudo port install php5-mcrypt
+    sudo port install php5-apc
     sudo port load apache2
 
 ----------------------------------------
@@ -140,7 +141,11 @@ If you happen to not have `yourdomain.com` registered, you can fake it by editin
 
 Now you're ready to launch your OpenPhoto site. Point your browser to your host and you'll be taken to a setup screen. You'll need your cloud account credentials to continue.
 
-Once you complete the 3 steps your site will be up and running and you'll be redirected there. The _setup_ screen won't show up anymore. If for any reason you want to go through the setup again you will need to delete the generated config file and refresh your browser.
+Once you complete the 3 steps your site will be up and running and you'll be redirected there. The _setup_ screen won't show up anymore.
+
+### Performing setup again ###
+
+If for any reason you want to go through the setup again you will need to delete the generated config file and refresh your browser.
 
     rm ~/Sites/yourdomain.com/src/userdata/configs/settings.ini
 


### PR DESCRIPTION
Adding missing APC installation step. It was in the comments of the previous Pull Request.
Also making a new section for performing setup again since it was lumped in with a successful installation.
