### PR TITLE
Add :focus pseudo class to slideshow arrows - refs #360

### DIFF
--- a/src/html/assets/themes/beisel/stylesheets/main.css
+++ b/src/html/assets/themes/beisel/stylesheets/main.css
@@ -919,7 +919,8 @@ html[xmlns] .slides {
   width:40px;
 }
 
-.flex-direction-nav li a.next:hover {
+.flex-direction-nav li a.next:hover,
+.flex-direction-nav li a.next:focus {
   background: #bebebe;
   background: -moz-linear-gradient(left, #bebebe 93%, #bebebe 95%, #999999 100%);
   background: -webkit-gradient(linear, left top, right top, color-stop(93%,#bebebe), color-stop(95%,#bebebe), color-stop(100%,#999999));


### PR DESCRIPTION
This adds visible change when the element is selected, since we have turned off the outline in commit f2ecc35 and will ensure that the element is accessible. The :hover styles have been reused for the :focus state.
