### PR TITLE
Fix various white space issues with tags

### DIFF
--- a/src/libraries/models/Photo.php
+++ b/src/libraries/models/Photo.php
@@ -351,7 +351,6 @@ class Photo
     $attributes = self::whitelistParams($attributes);
     if(isset($attributes['tags']) && !empty($attributes['tags']))
     {
-      $attributes['tags'] = Tag::removeDuplicatesFromString($attributes['tags']);
       $attributes['tags'] = Tag::sanitizeTagsAsString($attributes['tags']);
     }
     $status = getDb()->postPhoto($id, $attributes);
@@ -449,7 +448,6 @@ class Photo
         $attributes['longitude'] = floatval($exif['longitude']);
       if(isset($attributes['tags']) && !empty($attributes['tags']))
       {
-        $attributes['tags'] = Tag::removeDuplicatesFromString($attributes['tags']);
         $attributes['tags'] = Tag::sanitizeTagsAsString($attributes['tags']);
       }
 

--- a/src/libraries/models/Tag.php
+++ b/src/libraries/models/Tag.php
@@ -133,23 +133,19 @@ class Tag
     return $tags;
   }
 
-  public static function removeDuplicatesFromString($tags)
-  {
-    return implode(',', array_unique((array)explode(',', $tags)));
-  }
-
   public static function sanitize($tag)
   {
-    return preg_replace('/,/', '', $tag);
+    return trim(preg_replace('/,/', '', $tag));
   }
 
   public static function sanitizeTagsAsString($tags)
   {
-    $tagsArray = (array)explode(',', $tags);
-    natcasesort($tagsArray);
+    $tagsArray = preg_split('/\s*,\s*/', trim($tags), -1, PREG_SPLIT_NO_EMPTY);
+    $tagsArray = array_unique($tagsArray);
     foreach($tagsArray as $key => $val)
       $tagsArray[$key] = self::sanitize($val);
 
+    natcasesort($tagsArray);
     return implode(',', $tagsArray);
   }
 


### PR DESCRIPTION
This patch fixes white space issues with tags. If a user submits the following ...

" 2011, 2011 ,2011,"

... we'll end up with four different tags where actually this is only one valid tag. This happened to me because I submitted tags like "London, 2011" and "2011,February" were automatically added. We should trim the tags string and use preg_split() to handle commas enclosed by white spaces.
