### PR TITLE
Set character set to UTF-8 for MySQL connection. 

### DIFF
--- a/src/libraries/adapters/DatabaseMySql.php
+++ b/src/libraries/adapters/DatabaseMySql.php
@@ -29,6 +29,8 @@ class DatabaseMySql implements DatabaseInterface
       $this->{$key} = $value;
     }
 
+    getDatabase()->execute("SET NAMES 'utf8'");
+
     $user = getConfig()->get('user');
     if($user !== null)
       $this->owner = $user->email;


### PR DESCRIPTION
MySQL normally defaults to latin1 for the connection, if nothing else have been set in mysql config.
Without this, the string is stored in wrong encoding in the table, it appears to work from the
web frontend, but inspecting the data stored shows the problems.

Issue #403
