### PR TITLE
Should fix #564

### DIFF
--- a/src/libraries/external/epi/EpiDatabase.php
+++ b/src/libraries/external/epi/EpiDatabase.php
@@ -131,7 +131,10 @@ class EpiDatabase
     {
       // eventually split host to use a different
       //  sql port
-      list($host,$port) = split(':', $this->_host);
+      $host = $this->_host;
+      $host = strtok($host,":");
+      $port = strtok(":");
+
 
       $dsn = sprintf('%s:host=%s', $this->_type, $host);
       if ($port != '') 


### PR DESCRIPTION
Supporting uri in mysql connect string does not require adding further parameters.

eg.
[mysql]
mySqlHost="127.0.0.1:3306"

https://github.com/openphoto/frontend/issues/564
