### PR TITLE
Make sure that the Oauth Extension is loaded through php.ini

### DIFF
--- a/documentation/guides/InstallationUbuntuApache.markdown
+++ b/documentation/guides/InstallationUbuntuApache.markdown
@@ -109,6 +109,10 @@ Search for the following values and make sure they're correct.
     file_uploads = On
     upload_max_filesize = 16M
     post_max_size = 16M
+    
+Search for, and if needed add the following line to load the Oauth Extention.
+
+    extension=oauth.so
 
 Now you're ready to restart apache and visit the site in your browser.
 


### PR DESCRIPTION
The Ubuntu/Apache instructions, as they are, make no mention of needing to load the Oauth extension through php.ini. Required quite a few hours of hunting down what I was doing wrong, especially since the only indication that something was wrong was that I could not link my install to the iPhone app, something I would assume to be a pretty common use-case.
