### PR TITLE
Setup improvements

### DIFF
--- a/src/libraries/controllers/SetupController.php
+++ b/src/libraries/controllers/SetupController.php
@@ -565,7 +565,7 @@ class SetupController extends BaseController
       $serverUser = exec("whoami");
       if(!$fsObj->initialize($isEditMode))
       {
-        if($usesAws)
+        if($usesS3)
           $fsErrors[] = 'We were unable to initialize your S3 bucket.<ul><li>Make sure you\'re <a href="http://aws.amazon.com/s3/">signed up for AWS S3</a>.</li><li>Double check your AWS credentials.</li><li>S3 bucket names are globally unique, make sure yours isn\'t already in use by someone else.</li><li>S3 bucket names can\'t have certain special characters. Try using just alpha-numeric characters and periods.</li></ul>';
         else if($usesLocalFs)
           $fsErrors[] = "We were unable to set up your local file system using <em>{$fsObj->getRoot()}</em>. Make sure that the following user has proper permissions ({$serverUser}).";
@@ -574,7 +574,7 @@ class SetupController extends BaseController
       }
       if(!$dbObj->initialize($isEditMode))
       {
-        if($usesAws)
+        if($usesSimpleDb)
           $dbErrors[] = 'We were unable to initialize your SimpleDb domains.<ul><li>Make sure you\'re <a href="http://aws.amazon.com/simpledb/">signed up for AWS SimpleDb</a>.</li><li>Double check your AWS credentials.</li><li>SimpleDb domains cannot contain special characters such as periods.</li><li>Sometimes the SimpleDb create domain API is unstable. Try again later or check the error log if you have access to it.</li></ul>';
         else if($usesMySql)
           $dbErrors[] = 'We were unable to initialize your account in MySql. <ul><li>Please verify that the host, username and password are correct and have proper permissions to create a database.</li><li>Make sure your email address is not already in use.</li></ul>';


### PR DESCRIPTION
Two fixes to the setup process:
- The MySQL password was made optional because it’s not uncommon to have an empty database password on a test set-up;
- In the following situation:
  - Amazon S3 is used for storage
  - MySQL is used as the database
  - A MySQL error occurs
  
  a mix-up between `$usesAws`, `$usesS3` and `$usesSimpleDb` would cause a SimpleDB error to be reported instead of a MySQL error.
