### PR TITLE
add setCompressionQuality method to Image adapters

### DIFF
--- a/src/libraries/adapters/ImageAbstract.php
+++ b/src/libraries/adapters/ImageAbstract.php
@@ -14,6 +14,7 @@ abstract class ImageAbstract
   abstract public function scale($width, $height, $maintainAspectRatio = true);
   abstract public function greyscale();
   abstract public function write($outputFile);
+  abstract public function setCompressionQuality($quality);
 
   public function __construct()
   {

--- a/src/libraries/adapters/ImageGD.php
+++ b/src/libraries/adapters/ImageGD.php
@@ -25,6 +25,7 @@ class ImageGD extends ImageAbstract
   private $type;
 	private $width;
 	private $height;
+  private $quality = 90;
 
   /**
     * Quasi constructor
@@ -142,6 +143,14 @@ class ImageGD extends ImageAbstract
   }
 
   /**
+   * Set compression quality
+   */
+  public function setCompressionQuality($quality)
+  {
+    $this->quality = (int) $quality;
+  }
+
+  /**
     * Save modifications to the image to the file system
     *
     * @param string $outputFile The file to write the modifications to.
@@ -150,10 +159,10 @@ class ImageGD extends ImageAbstract
   public function write($outputFile)
   {
     if(preg_match('/png$/', $this->type))
-      imagepng($this->image, $outputFile, 9);
+      imagepng($this->image, $outputFile, ceil($this->quality / 10));
     elseif(preg_match('/gif$/', $this->type))
-      imagegif($this->image, $outputFile, 90);
+      imagegif($this->image, $outputFile, $this->quality);
     else
-      imagejpeg($this->image, $outputFile, 90);
+      imagejpeg($this->image, $outputFile, $this->quality);
   }
 }

--- a/src/libraries/adapters/ImageGraphicsMagick.php
+++ b/src/libraries/adapters/ImageGraphicsMagick.php
@@ -69,6 +69,16 @@ class ImageGraphicsMagick extends ImageAbstract
   }
 
   /**
+   * Set compression quality
+   */
+  public function setCompressionQuality($quality)
+  {
+    if (method_exists($this->image, 'setCompressionQuality')) {
+      $this->image->setCompressionQuality((int) $quality);
+    }
+  }
+
+  /**
     * Save modifications to the image to the file system
     *
     * @param string $outputFile The file to write the modifications to.

--- a/src/libraries/adapters/ImageImageMagick.php
+++ b/src/libraries/adapters/ImageImageMagick.php
@@ -71,6 +71,16 @@ class ImageImageMagick extends ImageAbstract
   }
 
   /**
+   * Set compression quality
+   */
+  public function setCompressionQuality($quality)
+  {
+    if (method_exists($this->image, 'setImageCompressionQuality')) {
+      $this->image->setImageCompressionQuality((int) $quality);
+    }
+  }
+
+  /**
     * Save modifications to the image to the file system
     *
     * @param string $outputFile The file to write the modifications to.


### PR DESCRIPTION
This will allow to produce different qualities for different sizes.
For the future high DPI support, it will allow to create higher resolution images that are not too heavy (and still look fine on Retina screens).
