### PR TITLE
Fix hover style on Beisel 2.0 tag list

### DIFF
--- a/src/html/assets/themes/beisel2.0/stylesheets/opme.css
+++ b/src/html/assets/themes/beisel2.0/stylesheets/opme.css
@@ -4247,6 +4247,9 @@ body.photos .album-list {
 body.tags div.tags .tag-list {
   padding:20px;
 }
+.tag-list a {
+  color: #e6501e;
+}
 .tag-1 {
   background-color:#f4bfde;
 }

--- a/src/html/assets/themes/beisel2.0/templates/tags.php
+++ b/src/html/assets/themes/beisel2.0/templates/tags.php
@@ -13,9 +13,7 @@
   <?php } else { ?>
     <div class="row hero-unit tag-list">
       <?php foreach($tags as $tag) { ?>
-        <span class="label label-tag tag-<?php $this->utility->safe($tag['weight']); ?>">
-          <a href="<?php $this->url->photosView(sprintf('tags-%s', $this->utility->safe($tag['id'], false))); ?>"><?php $this->utility->safe($tag['id']); ?></a>
-        </span>
+        <a class="label label-tag tag-<?php $this->utility->safe($tag['weight']); ?>" href="<?php $this->url->photosView(sprintf('tags-%s', $this->utility->safe($tag['id'], false))); ?>"><?php $this->utility->safe($tag['id']); ?></a>
       <?php } ?>
     </div>
   <?php } ?>

--- a/src/html/assets/themes/beisel2.0/templates/template.php
+++ b/src/html/assets/themes/beisel2.0/templates/template.php
@@ -38,7 +38,7 @@
                                                                   addCss("/assets/stylesheets/upload.css")->
                                                                   addCss($this->theme->asset('stylesheet', 'chosen.css', false))->
                                                                   addCss($this->theme->asset('stylesheet', 'opme.css', false))->
-                                                                  getUrl(AssetPipeline::css, 'am'); ?>">
+                                                                  getUrl(AssetPipeline::css, 'an'); ?>">
       <!--[if IE 7]>
         <link rel="stylesheet" href="<?php $this->utility->safe($this->config->site->cdnPrefix);?><?php echo getAssetPipeline(true)->addCss($this->theme->asset('stylesheet', 'font-awesome-2-ie7.css', false))->
                                                                   getUrl(AssetPipeline::css, 'a'); ?>">


### PR DESCRIPTION
Remove unneeded `<span>` wrapped around the tag links, apply classes to links
directly, just like on the photo detail page.

The hover state now doesn't lead to orange text on orange background anymore. Also,
the link area now matches the entire label box, not just the writing inside.

Fixes #845
