### PR TITLE
Keep "Drag photos here" area

### DIFF
--- a/src/html/assets/javascripts/jquery.plupload.queue.js
+++ b/src/html/assets/javascripts/jquery.plupload.queue.js
@@ -185,8 +185,8 @@
 
 					updateTotalProgress();
 
-					// Re-add drag message if there is no files
-					if (!uploader.files.length && uploader.features.dragdrop && uploader.settings.dragdrop) {
+					// Re-add drag message if there is no files or droptext is configured to be permanent
+					if (settings.keep_droptext || (!uploader.files.length && uploader.features.dragdrop && uploader.settings.dragdrop)) {
 						$('#' + id + '_filelist').append('<li class="plupload_droptext">' + _("Drag photos here.") + '</li>');
 					}
 				}

--- a/src/html/assets/javascripts/openphoto-upload.js
+++ b/src/html/assets/javascripts/openphoto-upload.js
@@ -33,6 +33,7 @@ OPU = (function() {
             file_data_name : 'photo',
             //chunk_size : '1mb',
             unique_names : true,
+            keep_droptext : true,
      
             // Specify what files to browse for
             filters : [


### PR DESCRIPTION
Add a setting "keep_droptext" to jquery.plupload.queue. If enabled,
the last element in the plupload filelist that serves as a big drop
area for adding files, will be kept even after files have been added.

Fixes #365

**Note**: Minified versions of the Javascript files and asset cache have NOT
been updated. I don't know which tool should be used for minification.
