### PR TITLE
Hide close button of Batch edit info box

### DIFF
--- a/src/html/assets/themes/beisel2.0/javascripts/openphoto-theme.js
+++ b/src/html/assets/themes/beisel2.0/javascripts/openphoto-theme.js
@@ -1249,10 +1249,12 @@ var opTheme = (function() {
           return;
         } else {
           opTheme.message.append(
-            markup.message(
-              '  <a id="batch-message"></a>You have <span id="batch-count">'+idsLength+'</span> photos pinned.' +
-              '  <div><a class="btn small info batch-modal-click" data-controls-modal="modal" data-backdrop="static">Batch edit</a>&nbsp;<a href="#" class="btn small pin-clear-click">Or clear pins</a></div>'
-            )
+            '<div class="batch-message-container">' +
+              markup.message(
+                '  <a id="batch-message"></a>You have <span id="batch-count">'+idsLength+'</span> photos pinned.' +
+                '  <div><a class="btn small info batch-modal-click" data-controls-modal="modal" data-backdrop="static">Batch edit</a>&nbsp;<a href="#" class="btn small pin-clear-click">Or clear pins</a></div>'
+              ) +
+            '</div>'
           );
         }
       },

--- a/src/html/assets/themes/beisel2.0/stylesheets/opme.css
+++ b/src/html/assets/themes/beisel2.0/stylesheets/opme.css
@@ -4351,6 +4351,9 @@ body.tags div.tags .tag-list {
        -o-transition:opacity linear 0.2s;
        transition:opacity linear 0.2s;
 }
+.batch-message-container .close {
+  display: none;
+}
 .manage.applications table td {
   width: 50%;
 


### PR DESCRIPTION
The info box should not be closeable, as it contains the reset button
for the batch edit pins.

This is not easy to target in CSS, adding an extra wrapper div for
this specific alert box with a `.batch-message-container` class.

Fixes #865
