### PR TITLE
Beisel2: Apply rounded corners to container instead of image

### DIFF
--- a/src/html/assets/themes/beisel2.0/stylesheets/opme.css
+++ b/src/html/assets/themes/beisel2.0/stylesheets/opme.css
@@ -4408,11 +4408,8 @@ body.tags div.tags .tag-list {
 }
 
 .photodetail .span9 img {
-	-webkit-border-top-left-radius: 5px;
-	-moz-border-top-left-radius: 5px;
-	border-top-left-radius: 5px;
-  display:block;
-  margin:auto;
+	display:block;
+	margin:auto;
 }
 
 .photodetail .span9 .form-horizontal {
@@ -4445,7 +4442,10 @@ body.tags div.tags .tag-list {
 }
 
 .photodetailpos {
-	position:relative;
+	border-top-left-radius: 5px;
+	-webkit-border-top-left-radius: 5px;
+	-moz-border-top-left-radius: 5px;
+	overflow: hidden;
 }
 
 .photodetailpos:hover .private {
@@ -4980,6 +4980,11 @@ header h1 {
 	.photodetail .camera {
 		margin-bottom:20px;
 	}
+	.photodetailpos {
+		border-top-right-radius: 5px;
+		-webkit-border-top-right-radius: 5px;
+		-moz-border-top-right-radius: 5px;
+}
 
   .manage.applications .credential-date {
     display:none;

--- a/src/html/assets/themes/beisel2.0/templates/template.php
+++ b/src/html/assets/themes/beisel2.0/templates/template.php
@@ -38,7 +38,7 @@
                                                                   addCss("/assets/stylesheets/upload.css")->
                                                                   addCss($this->theme->asset('stylesheet', 'chosen.css', false))->
                                                                   addCss($this->theme->asset('stylesheet', 'opme.css', false))->
-                                                                  getUrl(AssetPipeline::css, 'ao'); ?>">
+                                                                  getUrl(AssetPipeline::css, 'ap'); ?>">
       <!--[if IE 7]>
         <link rel="stylesheet" href="<?php $this->utility->safe($this->config->site->cdnPrefix);?><?php echo getAssetPipeline(true)->addCss($this->theme->asset('stylesheet', 'font-awesome-2-ie7.css', false))->
                                                                   getUrl(AssetPipeline::css, 'a'); ?>">


### PR DESCRIPTION
Instead of rounding the corner (top left, also top right in single
column layout) of the image, round the container instead.
If the image doesn't fill the container width, it will not have an
unmotivated rounded corner anymore.

Note: For webkit, any positioning of the container needs to be removed,
see http://stackoverflow.com/q/5736503/376138
Removing `position: relative` doesn't seem to break anything, though.

Fixes #912

I did some manual browser tests:
Chromium 18, Firefox 13, Safari 5.0.2, IE9, Android 2.3: works, no obvious regressions.
IE7: No rounded corners anyway, no obvious regressions.
Opera 12: Does not clip image at the rounded corners of the container, result: straight corners. **Regression**: rounded corners directly on image worked before.

I'm leaving this branch running for while on [my OP installation](http://photos.pixelistik.de/), feel free to test it there. Specifically, there's a [narrow test image in portrait orientation](http://photos.pixelistik.de/p/b).  **Edit:** I'm back on a different branch now.
