### PR TITLE
Modified the album/update API endpoint to return the updated album.

### DIFF
--- a/src/libraries/controllers/ApiAlbumController.php
+++ b/src/libraries/controllers/ApiAlbumController.php
@@ -128,7 +128,8 @@ class ApiAlbumController extends ApiBaseController
     if(!$status)
       return $this->error('Could not update album', false);
 
-    return $this->success('Album updated', true);
+    $albumResp = $this->api->invoke("/{$this->apiVersion}/album/{$id}/view.json", EpiRoute::httpGet);
+    return $this->success('Album {$id} updated', $albumResp['result']);
   }
 
   public function view($id)


### PR DESCRIPTION
This now matches the behaviour of the tag and photo APIs.

Let me know if I've misunderstood your intentions, but it seems like a good idea to have consistent behaviour for the update endpoint across all object types.

Will this need to wait for the next API version bump?
