### PR TITLE
Fixed white gap at bottom of photo details page

### DIFF
--- a/src/html/assets/themes/beisel2.0/templates/photo-details.php
+++ b/src/html/assets/themes/beisel2.0/templates/photo-details.php
@@ -73,7 +73,7 @@
               </div>
             </fieldset>
           </form>
-          <form method="post" action="<?php $this->url->actionCreate($photo['id'], 'photo'); ?>" id="favorite-form">
+          <form method="post" action="<?php $this->url->actionCreate($photo['id'], 'photo'); ?>" id="favorite-form" class="hidden">
             <input type="hidden" name="type" value="favorite">
             <input type="hidden" name="targetUrl" value="<?php $this->utility->safe(sprintf('http://%s%s', $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'])); ?>">
             <input type="hidden" name="crumb" value="<?php $this->utility->safe($crumb); ?>">


### PR DESCRIPTION
Fixed the white gap at the bottom of the photo details page by adding the "hidden" class to the form to keep it from taking up vertical space.
