### PR TITLE
tagsAdd should have priority over tagsRemove

### DIFF
--- a/src/libraries/controllers/ApiPhotoController.php
+++ b/src/libraries/controllers/ApiPhotoController.php
@@ -530,15 +530,15 @@ class ApiPhotoController extends ApiBaseController
         else
         {
           $updatedTags = $existingTags;
-          if(isset($params['tagsAdd']))
-          {
-            $updatedTags = array_merge($updatedTags, (array)explode(',', $params['tagsAdd']));
-            unset($params['tagsAdd']);
-          }
           if(isset($params['tagsRemove']))
           {
             $updatedTags = array_diff($updatedTags, (array)explode(',', $params['tagsRemove']));
             unset($params['tagsRemove']);
+          }
+          if(isset($params['tagsAdd']))
+          {
+            $updatedTags = array_merge($updatedTags, (array)explode(',', $params['tagsAdd']));
+            unset($params['tagsAdd']);
           }
           $params['tags'] = implode(',', $updatedTags);
         }


### PR DESCRIPTION
A minor tweak: if a tag is both added and removed in the same API call:

```
photo.update(tagsRemove="test", tagsAdd="test")
```

I think the result should be that the tag is retained.

To achieve this, process the tagsRemove parameter first, then the tagsAdd parameter.
