### PR TITLE
Always call credential->checkRequest() when creating an OAuth credential object. Fixes #929

### DIFF
--- a/src/libraries/models/User.php
+++ b/src/libraries/models/User.php
@@ -266,6 +266,12 @@ class User extends BaseModel
       return $this->credential;
 
     $this->credential = new Credential;
+    if($this->credential->isOAuthRequest()) {
+      // Process the OAuth request
+      if (!$this->credential->checkRequest()) {
+	$this->logger->warn($this->credential->getErrorAsString());
+      }
+    }
     return $this->credential;
   }
 


### PR DESCRIPTION
From what I can see, various credential functions don't work if you don't call $credential->checkRequest() beforehand.

In User->getEmailAddress(), for example, $credential->getEmailFromOAuth() returns an empty string unless $credential->checkRequest() has been called previously.

It seems best to call checkRequest() immediately after creating $credential (or there are any cases where this would be expected to fail?)

See Issue #929 for repro instructions.
