### PR TITLE
Return success/failed details on photo update and delete

### DIFF
--- a/src/libraries/controllers/ApiPhotoController.php
+++ b/src/libraries/controllers/ApiPhotoController.php
@@ -60,14 +60,17 @@ class ApiPhotoController extends ApiBaseController
     unset($params['ids']);
 
     $retval = true;
+    $deletedIds = array();
     foreach($ids as $id)
     {
       $response = $this->api->invoke("/{$this->apiVersion}/photo/{$id}/delete.json", EpiRoute::httpPost, array('_POST' => $params));
       $retval = $retval && $response['result'] !== false;
+      if($response['result'] !== false)
+        $deletedIds[] = $id;
     }
 
     if($retval)
-      return $this->noContent(sprintf('%d photos deleted', count($ids)), true);
+      return $this->noContent(sprintf('%d photos deleted', count($ids)), $deletedIds);
     else
       return $this->error('Error deleting one or more photos', false);
   }

--- a/src/libraries/controllers/ApiPhotoController.php
+++ b/src/libraries/controllers/ApiPhotoController.php
@@ -669,16 +669,21 @@ class ApiPhotoController extends ApiBaseController
     unset($params['ids']);
 
     $retval = true;
+    $batchResults = array('success' => array(), 'failed' => array());
     foreach($ids as $id)
     {
       $response = $this->api->invoke("/{$this->apiVersion}/photo/{$id}/update.json", EpiRoute::httpPost, array('_POST' => $params));
       $retval = $retval && $response['result'] !== false;
+      if($response['result'] === false)
+        $batchResults['failed'][] = $id;
+      else
+        $batchResults['success'][] = $id;
     }
 
     if($retval)
-      return $this->success(sprintf('%d photos updated', count($ids)), true);
+      return $this->success(sprintf('%d photos updated', count($ids)), $batchResults);
     else
-      return $this->error('Error updating one or more photos', false);
+      return $this->error('Error updating one or more photos', $batchResults);
   }
 
   /**

--- a/src/libraries/controllers/ApiPhotoController.php
+++ b/src/libraries/controllers/ApiPhotoController.php
@@ -60,19 +60,21 @@ class ApiPhotoController extends ApiBaseController
     unset($params['ids']);
 
     $retval = true;
-    $deletedIds = array();
+    $batchResults = array('success' => array(), 'failed' => array());
     foreach($ids as $id)
     {
       $response = $this->api->invoke("/{$this->apiVersion}/photo/{$id}/delete.json", EpiRoute::httpPost, array('_POST' => $params));
       $retval = $retval && $response['result'] !== false;
-      if($response['result'] !== false)
-        $deletedIds[] = $id;
+      if($response['result'] === false)
+        $batchResults['failed'][] = $id;
+      else
+        $batchResults['success'][] = $id;
     }
 
     if($retval)
-      return $this->noContent(sprintf('%d photos deleted', count($ids)), $deletedIds);
+      return $this->noContent(sprintf('%d photos deleted', count($ids)), $batchResults);
     else
-      return $this->error('Error deleting one or more photos', false);
+      return $this->error('Error deleting one or more photos', $batchResults);
   }
 
   /**

--- a/src/libraries/models/Utility.php
+++ b/src/libraries/models/Utility.php
@@ -318,6 +318,13 @@ class Utility
       return $this->returnValue(($int != 1 ? "{$word}s" : $word), $write);
   }
 
+  public function selectPlural($int, $singularForm, $pluralForm, $write = true)
+  {
+    $singularForm = $this->safe($singularForm, false);
+    $pluralForm = $this->safe($pluralForm, false);
+    return $this->returnValue(($int != 1 ? $pluralForm : $singularForm), $write);
+  }
+
   public function posessive($noun, $write = true)
   {
     if(substr($noun, -1) === 's')

--- a/src/templates/uploadConfirm.php
+++ b/src/templates/uploadConfirm.php
@@ -28,7 +28,7 @@
 
 <?php if(count($successPhotos) > 0) { ?>
   <h3>Here's a breakdown of your upload</h3>
-  <strong><span class="label label-success"><?php printf('%d %s', count($successPhotos), $this->utility->plural(count($successPhotos), 'photo', false)); ?> were uploaded successfully.</span></strong>
+  <strong><span class="label label-success"><?php printf('%d %s %s', count($successPhotos), $this->utility->plural(count($successPhotos), 'photo', false), $this->utility->selectPlural(count($successPhotos), 'was', 'were', false)); ?> uploaded successfully.</span></strong>
   <div class="upload-preview">
     <ul class="thumbnails">
       <?php foreach($successPhotos as $photo) { ?>

--- a/src/tests/libraries/models/UtilityTest.php
+++ b/src/tests/libraries/models/UtilityTest.php
@@ -228,6 +228,18 @@ RES;
     $this->assertEquals('words', $res, 'plural for word with 2 incorrect');
   }
 
+  public function testSelectPlural()
+  {
+    $res = $this->utility->selectPlural(0, 'was', 'were', false);
+    $this->assertEquals('were', $res, 'plural for word with 0 selected incorrectly');
+
+    $res = $this->utility->selectPlural(1, 'was', 'were', false);
+    $this->assertEquals('was', $res, 'plural for word with 1 selected incorrectly');
+
+    $res = $this->utility->selectPlural(2, 'was', 'were', false);
+    $this->assertEquals('were', $res, 'plural for word with 2 selected incorrectly');
+  }
+
   public function testReturnValue()
   {
     $res = $this->utility->returnValue('foo', false);


### PR DESCRIPTION
Following the discussion on #1066 this is a new response format that
provides detailed feedback on which photos the operation worked.