### PR TITLE
Define baseHost and rewriteHost in defaults.ini to prevent PHP notices.

### DIFF
--- a/src/configs/defaults.ini
+++ b/src/configs/defaults.ini
@@ -13,6 +13,8 @@ allowOpenPhotoLogin=1
 cdnPrefix=""
 hideFromSearchEngines=0
 pluginWhitelist=""
+baseHost=""
+rewriteHost=""
 
 [secrets]
 passwordSalt="salt_for_passwords"


### PR DESCRIPTION
Fixes #1100
