### PR TITLE
Use REQUEST_URI instead of REDIRECT_URL. #1131

### DIFF
--- a/src/libraries/models/Utility.php
+++ b/src/libraries/models/Utility.php
@@ -128,7 +128,7 @@ class Utility
 
   public function getPath()
   {
-    return $_SERVER['REDIRECT_URL'];
+    return $_SERVER['REQUEST_URI'];
   }
 
   public function dateLong($ts, $write = true)


### PR DESCRIPTION
REQUEST_URI is set in most servers, REDIRECT_URL is not. This commit fixes PHP warnings for nginx/php-fpm.

Can somebody with Apache/mod-php confirm that REQUEST_URI works?
