### PR TITLE
Do not overwrite $options parameter. #1113

### DIFF
--- a/src/libraries/controllers/ApiPhotoController.php
+++ b/src/libraries/controllers/ApiPhotoController.php
@@ -757,6 +757,7 @@ class ApiPhotoController extends ApiBaseController
     * Retrieve a photo from the remote datasource.
     *
     * @param string $id ID of the photo to be viewed.
+    * @param string $options Optional options for rendering this photo.
     * @return string Standard JSON envelope
     */
   public function view($id, $options = null)
@@ -818,11 +819,11 @@ class ApiPhotoController extends ApiBaseController
 
       foreach($sizes as $size)
       {
-        $options = $this->photo->generateFragmentReverse($size);
+        $fragment = $this->photo->generateFragmentReverse($size);
         if($generate && !isset($photo["path{$size}"]))
         {
-          $hash = $this->photo->generateHash($id, $options['width'], $options['height'], $options['options']);
-          $this->photo->generate($id, $hash, $options['width'], $options['width'], $options['options']);
+          $hash = $this->photo->generateHash($id, $fragment['width'], $fragment['height'], $fragment['options']);
+          $this->photo->generate($id, $hash, $fragment['width'], $fragment['width'], $fragment['options']);
           $requery = true;
         }
       }


### PR DESCRIPTION
The reason for #1113 was that $options was being overwritten by something else, which had two effects
- the options were never passed to the nextprevious call (which may have affected #1108)
- PHP Notice about array to string conversion
