### PR TITLE
Fixed user not being asked for password during setup

### DIFF
--- a/src/templates/setup.php
+++ b/src/templates/setup.php
@@ -28,7 +28,7 @@
       <label for="email">Email address</label>
       <input type="text" name="email" id="email" placeholder="user@example.com" <?php if(isset($email)) { ?>value="<?php $this->utility->safe($email); ?>"<?php } ?> data-validation="required email">
 
-      <?php if($this->config->site->allowTroveboxLogin == 1) { ?>
+      <?php if($this->config->site->allowOpenPhotoLogin == 1) { ?>
         <label for="email">Password</label>
         <input type="password" name="password" id="password" placeholder="password" <?php if(isset($password)) { ?>value="<?php $this->utility->safe($password); ?>"<?php } ?> data-validation="required">
       <?php } else { ?>


### PR DESCRIPTION
A variable name issue was preventing the user from being shown the "create password" box during setup.

Partly solves issue #1198.
