### PR TITLE
Provide an html link in the email that it is actually clickable

### DIFF
--- a/src/libraries/controllers/ApiShareController.php
+++ b/src/libraries/controllers/ApiShareController.php
@@ -50,7 +50,8 @@ class ApiShareController extends ApiController
       $params['photo'] = $albumResp['result']['cover']['path200x200xCR'];
       $params['title'] = $albumResp['result']['name'];
       $utilityObj = new Utility;
-      $params['url'] = sprintf('http://%s/photos/album-%s/token-%s/list', $utilityObj->getHost(), $data, $token);
+      $path = sprintf('/photos/album-%s/token-%s/list', $data, $token);
+      $params['url'] = $utilityObj->getAbsoluteUrl($path, false);
       $params['permission'] = 0;
     }
 
@@ -89,7 +90,7 @@ class ApiShareController extends ApiController
 
     $body = nl2br($_POST['message']);
     $body .= sprintf('<p><img src="%s" style="padding:3px; border:solid 1px #ccc;"></p>', $album['cover']['path200x200xCR']);
-    $body .= sprintf("\n<br><br>Click the link below to view the album.<br>\n%s", $_POST['url']);
+    $body .= sprintf('<br><br>Click the link below to view the album.<br><a href="%s">%s</a>', $_POST['url'], $_POST['url']);
 
     $subject = sprintf('The album "%s" has been shared with you', $album['name']);
     $emailer->setSubject($subject);


### PR DESCRIPTION
- use the right API to construct the URL (e.g. http vs. https)
- make it <a href=... instead of just the URL to make it clickable
- Also remove the erroneous \n strings (they're not newlines)
