### PR TITLE
Should not build the date separator depending on client Timezone

### DIFF
--- a/src/html/assets/themes/fabrizio1.0/javascripts/gallery.js
+++ b/src/html/assets/themes/fabrizio1.0/javascripts/gallery.js
@@ -180,8 +180,6 @@ var Gallery = (function($) {
     var qs = pageObject.pageLocation.search.replace(qsRe, '');
     var pinnedClass = !batchEmpty && OP.Batch.exists(item.id) ? 'pinned' : '';
     var imageContainer = $('<div class="imageContainer photo-id-'+item.id+' '+pinnedClass+'"/>');
-		
-    var d = new Date(item.dateTaken*1000);
 
 		var pathKey = 'path' + configuration['thumbnailSize'];
 		var defaultWidthValue = configuration['defaultWidthValue'];
@@ -220,9 +218,10 @@ var Gallery = (function($) {
 		imageContainer.append(overflow);
 
     // insert calendar icon
+	var d = new Date(item.dateTakenYear, item.dateTakenMonth, item.dateTakenDay);
     currentDate = d.getYear()+'-'+d.getMonth()+'-'+d.getDay();
     if(currentDate !== lastDate)
-      imageContainer.prepend(dateSeparator(item.dateTaken));
+      imageContainer.prepend(dateSeparator(d.getTime()/1000));
     lastDate = currentDate;
     
     /**


### PR DESCRIPTION
Timestamp of all photos is assumed to be in America/Los_Angeles Timezone. This creates problem when this timestamp is interpreted in the client in a different timezone. The client assumes the timestamp is in its own timezone...

Anyway, all users in any timezone should see the same date for a given photo, so no timestamp should be interpreted (e.g. phpjs.date(ts) or new Date(ts)) in the client.

This is independant from the fact that the photo has or not a timezone information.

Not sure if this is explanatory enough. I can explain/give use case/test photos if needed.

This bugfix is kind of hacky. You might want to rewrite everything in UTC as per https://github.com/photo/frontend/issues/321
