### PR TITLE
Implemented tarball generation for photos

### DIFF
--- a/src/html/assets/themes/fabrizio1.0/config/tutorial.ini
+++ b/src/html/assets/themes/fabrizio1.0/config/tutorial.ini
@@ -3,9 +3,10 @@
 
 [tutorialPhotos]
 1='{"selector":".navbar .navbar-inner ul.nav li.batch .selectAll","intro":"<p>Select a photo by clicking the pushpin or alt+clicking the photo.</p><img src=\"/assets/themes/fabrizio1.0/images/highlight-pushpin.jpg\" style=\"width:200px; height:142px;\"><p>To select a range shift+click the first and last photo in the range.</p>","width":"200"}'
-2='{"selector":".navbar .navbar-inner ul.nav li.batch.dropdown a:first","intro":"Edit multiple photos using your Batch Queue.","width":"200"}'
+2='{"selector":".navbar .navbar-inner ul.nav li.batch.dropdown a:first","intro":"Edit or download multiple photos using your Batch Queue.","width":"200"}'
 3='{"selector":".container .userbadge h4.username span","intro":"This is the name of your site. Change it by clicking.","width":"200"}'
 4='{"selector":".container .userbadge .details","intro":"This is your account by the numbers."}'
+5='{"selector":".loadAlbumIds .tarball","intro":"Download a whole album as tar or zip archive"}'
 
 [tutorialUpload]
 1='{"selector":"form.upload .showBatchForm.album","intro":"Create a new album for these photos.","width":"150"}'

--- a/src/html/assets/themes/fabrizio1.0/javascripts/fabrizio.js
+++ b/src/html/assets/themes/fabrizio1.0/javascripts/fabrizio.js
@@ -379,15 +379,19 @@
       model: new op.data.model.Notification,
       errorIcon: '<i class="icon-warning-sign"></i>',
       successIcon: '<i class="icon-ok"></i>',
+      spinnerIcon: '<i class="icon-spinner icon-spin"></i>',
       init: function() {
         var $el = $('.notification-meta'), view = new op.data.view.Notification({model: TBX.notification.model, el: $el});
       },
       show: function(message, type, mode) {
         var model = TBX.notification.model;
-        if(mode === 'confirm' || typeof mode === 'undefined')
+        if(mode === 'confirm' || typeof mode === 'undefined') {
           message = TBX.notification.successIcon + ' ' + message;
-        else
+        } else if (mode === 'spin') {
+          message = TBX.notification.spinnerIcon + ' ' + message;
+        } else {
           message = TBX.notification.errorIcon + ' ' + message;
+        }
 
         type = type || 'flash';
 

--- a/src/html/assets/themes/fabrizio1.0/javascripts/op/Callbacks.js
+++ b/src/html/assets/themes/fabrizio1.0/javascripts/op/Callbacks.js
@@ -28,8 +28,13 @@
       $('.batchHide').trigger('click');
     };
     this.batch = function(response) { // this is the form params
-      var id, model, ids = this.ids.split(','), photoCount = ids.length, store = op.data.store.Photos, action = response.code === 204 ? 'deleted' : 'updated';
-      if(response.code === 200 || response.code === 204) {
+      var id,url, model, ids = this.ids.split(','), photoCount = ids.length, store = op.data.store.Photos, action = response.code === 204 ? 'deleted' : 'updated';
+
+      if (response.code === 201) {
+          TBX.notification.show(photoCount + ' photo ' + (photoCount>1?'s were':'was') + ' zipped.', 'flash', 'confirm');
+          url = "/photo/" + response.fileName + "/tarball?outputName=" + response.outputName;
+          location.href = url;
+      } else if(response.code === 200 || response.code === 204) {
         for(i in ids) {
           if(ids.hasOwnProperty(i)) {
             id = ids[i];

--- a/src/html/assets/themes/fabrizio1.0/javascripts/op/Callbacks.js
+++ b/src/html/assets/themes/fabrizio1.0/javascripts/op/Callbacks.js
@@ -28,12 +28,11 @@
       $('.batchHide').trigger('click');
     };
     this.batch = function(response) { // this is the form params
-      var id,url, model, ids = this.ids.split(','), photoCount = ids.length, store = op.data.store.Photos, action = response.code === 204 ? 'deleted' : 'updated';
-
+      var id,url,result, model, ids = this.ids.split(','), photoCount = ids.length, store = op.data.store.Photos, action = response.code === 204 ? 'deleted' : 'updated';
       if (response.code === 201) {
-          TBX.notification.show(photoCount + ' photo ' + (photoCount>1?'s were':'was') + ' zipped.', 'flash', 'confirm');
-          url = "/photo/" + response.fileName + "/tarball?outputName=" + response.outputName;
-          location.href = url;
+          result = response.result;
+          url = "/photo/" + result.fileName + "/tarball?outputName=" + result.outputName;
+          TBX.notification.show('Your archive was generated successfully. ' + result.success + '/' + photoCount + ' photo' + (photoCount>1?'s were':'was') + ' zipped. <a href=' + url + '><i class="icon-download"></i> ' + result.outputName + '</a>' , 'flash', 'confirm');
       } else if(response.code === 200 || response.code === 204) {
         for(i in ids) {
           if(ids.hasOwnProperty(i)) {

--- a/src/html/assets/themes/fabrizio1.0/templates/partials/batch-update-form.php
+++ b/src/html/assets/themes/fabrizio1.0/templates/partials/batch-update-form.php
@@ -70,7 +70,36 @@
           <input type="radio" name="permission" value="1"> Public 
         </label>
         &nbsp;&nbsp;
+      <?php } elseif($action == 'tarball') {?>
+      <?php
+          $buttonLabel = "Download";
+      ?>
+      <?php if(isset($ids)) { ?>
+        <input type="hidden" name="ids" value="<?php $this->utility->safe($ids); ?>">
       <?php } ?>
+        <h4>Choose an output format</h4>
+          <div class="control-group">
+            <select class="chooseFormat" name="archive" >
+              <?php $installed = shell_exec("which tar"); 
+              if (empty($installed)?false:true) {?>
+                <option value="tar">tar</option>
+              <?php } ?>     
+              <?php $installed = shell_exec("which zip"); 
+              if (empty($installed)?false:true) {?>
+                <option value="zip">zip</option>     
+              <?php } ?>        
+            </select>
+          </div>
+          <label class="checkbox">
+            <input type="checkbox" name="gzip" value="true"> gzip?
+          </label>
+          <h4>... and a name for the file</h4>
+          <label class="checkbox">
+            <input id="archiveAlbumName" type="text" value="Images" name="name">
+          </label>
+
+        &nbsp;&nbsp;
+      <?php } ?>      
       <button type="submit" class="btn btn-brand"><?php $this->utility->safe($buttonLabel); ?></button> or <a href="#" class="batchHide">cancel</a>
       <?php if(isset($ids)) { ?>
         <input type="hidden" name="ids" value="<?php $this->utility->safe($ids); ?>">

--- a/src/html/assets/themes/fabrizio1.0/templates/partials/batch-update-form.php
+++ b/src/html/assets/themes/fabrizio1.0/templates/partials/batch-update-form.php
@@ -72,32 +72,31 @@
         &nbsp;&nbsp;
       <?php } elseif($action == 'tarball') {?>
       <?php
-          $buttonLabel = "Download";
+          $buttonLabel = "Archive";
       ?>
       <?php if(isset($ids)) { ?>
         <input type="hidden" name="ids" value="<?php $this->utility->safe($ids); ?>">
       <?php } ?>
         <h4>Choose an output format</h4>
           <div class="control-group">
-            <select class="chooseFormat" name="archive" >
-              <?php $installed = shell_exec("which tar"); 
-              if (empty($installed)?false:true) {?>
-                <option value="tar">tar</option>
-              <?php } ?>     
-              <?php $installed = shell_exec("which zip"); 
-              if (empty($installed)?false:true) {?>
-                <option value="zip">zip</option>     
-              <?php } ?>        
+            <select class="chooseFormat" name="format" >
+                <option value="0">tar</option>
+                <option value="1">zip</option>     
             </select>
           </div>
-          <label class="checkbox">
-            <input type="checkbox" name="gzip" value="true"> gzip?
+          <label class="radio inline compression">
+            <input type="radio" name="compression" value="0" checked="checked" class="batchTagMode"> none 
+          </label>
+          <label class="radio inline compression">
+            <input type="radio" name="compression" value="1" class="batchTagMode"> gzip 
+          </label>
+          <label class="radio inline compression">
+            <input type="radio" name="compression" value="2" class="batchTagMode"> bzip2 
           </label>
           <h4>... and a name for the file</h4>
           <label class="checkbox">
-            <input id="archiveAlbumName" type="text" value="Images" name="name">
+            <input id="archiveAlbumName" type="text" value="Images" name="archivename">
           </label>
-
         &nbsp;&nbsp;
       <?php } ?>      
       <button type="submit" class="btn btn-brand"><?php $this->utility->safe($buttonLabel); ?></button> or <a href="#" class="batchHide">cancel</a>

--- a/src/html/assets/themes/fabrizio1.0/templates/partials/header-secondary.php
+++ b/src/html/assets/themes/fabrizio1.0/templates/partials/header-secondary.php
@@ -14,6 +14,7 @@
               <li class="batch separator-left"><a href="#" class="selectAll"><i class="icon-pushpin"></i> Select all</a></li>
               <li class="batch dropdown batch-meta"></li>
               <?php if($this->utility->isActiveTab('photos-album')) { ?>
+                <li><a href="#" class="loadAlbumIds tarball" data-action="tarball"><i class="icon-download loadAlbumIds tarball"></i> Download this album</a></li>
                 <li><a href="#" class="triggerShare"><i class="icon-share-alt triggerShare"></i> Share this album</a></li>
               <?php } ?>
             <?php } ?>

--- a/src/html/assets/themes/fabrizio1.0/templates/partials/underscore.php
+++ b/src/html/assets/themes/fabrizio1.0/templates/partials/underscore.php
@@ -438,6 +438,7 @@
           <li><a href="#" class="showBatchForm photo" data-action="albums">&nbsp;&middot;&nbsp;Manage Albums</a></li>
           <li><a href="#" class="showBatchForm photo" data-action="privacy">&nbsp;&middot;&nbsp;Manage Privacy</a></li>
           <li><a href="#" class="showBatchForm photo" data-action="delete">&nbsp;&middot;&nbsp;Delete</a></li>
+          <li><a href="#" class="showBatchForm tarball" data-action="tarball">&nbsp;&middot;&nbsp;Download</a></li>
           <!--<li><a href="#">&nbsp;&middot;&nbsp;Edit Date and Location</a></li>-->
           <!--<li class="divider"></li>
           <li><a>Modify photos</a></li>

--- a/src/html/assets/themes/fabrizio1.0/templates/photos.php
+++ b/src/html/assets/themes/fabrizio1.0/templates/photos.php
@@ -11,7 +11,7 @@
         (
           <?php $this->utility->safe($album['count']); ?> photos
           <?php if($this->user->isAdmin()) { ?>
-            <span class="hide"> | <a href="#" class="shareAlbum share trigger" data-id="<?php $this->utility->safe($album['id']); ?>" title="Share this album"><i class="icon-share"></i> Share</a></span>
+            <span class="hide"> | <a href="#" class="shareAlbum share trigger" data-id="<?php $this->utility->safe($album['id']); ?>" data-name="<?php $this->utility->safe($album['name']); ?>" title="Share this album"><i class="icon-share"></i> Share</a></span>
           <?php } ?>
         )
       </small>

--- a/src/libraries/controllers/ApiAlbumController.php
+++ b/src/libraries/controllers/ApiAlbumController.php
@@ -180,23 +180,4 @@ class ApiAlbumController extends ApiBaseController
 
     return $this->success('Album', $album);
   }
-  
-  public function listAlbumIds ($id) {
-    $userObj = new User;
-    if ($userObj->isAdmin()) {
-      $db=getDb('MySql');
-      $ids=array();
-      $albumPhotos = $db->getAlbumElements($id);
-
-      foreach ($albumPhotos as $photo) {
-        array_push($ids, $photo['id']);
-      }
-      
-      return $this->success ('List of the photo ids in the album',json_encode($ids));
-    } else {
-        return $this->error('Could not retrieve ids.', false);
-    }
-  }
 }
-
-

--- a/src/libraries/controllers/ApiAlbumController.php
+++ b/src/libraries/controllers/ApiAlbumController.php
@@ -180,4 +180,23 @@ class ApiAlbumController extends ApiBaseController
 
     return $this->success('Album', $album);
   }
+  
+  public function listAlbumIds ($id) {
+    $userObj = new User;
+    if ($userObj->isAdmin()) {
+      $db=getDb('MySql');
+      $ids=array();
+      $albumPhotos = $db->getAlbumElements($id);
+
+      foreach ($albumPhotos as $photo) {
+        array_push($ids, $photo['id']);
+      }
+      
+      return $this->success ('List of the photo ids in the album',json_encode($ids));
+    } else {
+        return $this->error('Could not retrieve ids.', false);
+    }
+  }
 }
+
+

--- a/src/libraries/controllers/PhotoController.php
+++ b/src/libraries/controllers/PhotoController.php
@@ -106,7 +106,6 @@ class PhotoController extends BaseController
       }
     }
 
-
     $this->route->run('/error/404');
   }
 
@@ -200,6 +199,7 @@ class PhotoController extends BaseController
     // TODO include success/error paramter
     $this->route->redirect($this->url->photoView($id, null, false));
   }
+
   /**
     * Display the upload form for photos.
     *
@@ -307,24 +307,23 @@ class PhotoController extends BaseController
     $fileName    = $path;
     $outputName  = $_GET['outputName'];
     $format      =  array_pop(explode (".",$fileName));
-
-    $file =  $this->config->paths->temp . "/$path-tarballSecret";
+    $file =  $this->config->paths->temp . "/$fileName-tarballSecret";
 
     if (file_exists($file)) {
-
-
       header('Content-Description: File Transfer');
       header($_SERVER["SERVER_PROTOCOL"] . " 200 OK");
       header("Cache-Control: public"); // needed for i.e.
-
       header('Content-Type: application/octet-stream');
+
       if ($format==='zip') {
-          header("Content-Type: application/zip"); 
+        header("Content-Type: application/zip"); 
       } else if ($format === 'tar') {
-          header("Content-Type: application/x-tar");
+        header("Content-Type: application/x-tar");
       } else if ($format === 'tar.gz') {
         header("Content-Type: application/x-gzip");
-      }
+      } else if ($format === 'tar.gz') {
+        header("Content-Type: application/x-bz2");
+      } 
 
       header("Content-Transfer-Encoding: Binary");
       header("Content-Length:".filesize($file));
@@ -342,91 +341,5 @@ class PhotoController extends BaseController
     } else {
           $this->route->run('/error/404');
     }
-
-  }
-
-
-  public function createTarball()
-  {
-
-    $format   = $_POST['archive'];
-    $filename = $_POST['name'];
-    $gzip     = $_POST['gzip'];
-    $idStr    = $_POST['ids'];
-    $ids      = explode(",", $id);
-    $id       = $ids[0];
-    $pathes   = array ();
-    $count    = count($ids);
-    $ext      = $format;
-
-    if ($format !== 'zip') {
-      $format = 'tar';
-    } 
-
-    if ($gzip === 'true' && $format === 'tar') {
-       $ext = 'tar.gz';
-    }
-
-    if ($filename === '') {
-      $filename = 'tarball';
-    }
-
-    
-    for ($i=0; $i < $count; $i++) { 
-      $id = $ids[$i];
-
-      $apiResp = $this->api->invoke("/photo/{$id}/view.json", EpiRoute::httpGet, array('_GET' => array('actions' => 'true', 'returnSizes' => $this->config->photoSizes->detail)));
-
-      if($apiResp['code'] === 200) {
-        $img = $_SERVER['DOCUMENT_ROOT'] . '/photos' . str_replace(array ("http://","https://",$apiResp['result']['host']), "", $apiResp['result']['pathOriginal']);
-        array_push($pathes, $img);
-      }    
-    }
-
-
-    if (count($pathes) === 0) {
-      $this->route->run('/error/404');
-    }
-
-    //get the folder path
-    $folder    = explode ( "/" , $pathes[0]);
-    $folder    = array_slice($folder, 0, count($folder) - 1 );
-    $folder    = implode('/', $folder);
-
-    $tmp       =  tempnam( $this->config->paths->temp, $filename);
-    $path      = $tmp . ".$ext" . '-tarballSecret';
-    $images    = implode(' ', $pathes);
-
-    $installed = shell_exec("which $format");
-    $installed = empty ($installed) ? false : true;
-
-    $flags = "";
-
-    if ($installed === false) {
-      header($_SERVER["SERVER_PROTOCOL"] . " 400");
-      die ();
-    }
-
-    if ($format === "tar") {
-      $flags = "-c";
-
-      if ($gzip === 'true') {
-        $flags .= "z";
-      }
-
-      $evl = "tar $flags -f $path -C $folder $images 2>&1";
-    } else {
-      $evl = "zip $flags -j $path $images 2>&1";
-    }
-
-    shell_exec($evl);
-    
-    $tmpFileName = array_pop ( explode("/", $tmp));
-
-    $result = (object) array("fileName" => $tmpFileName.".$ext", "outputName" => $filename.".$ext", "code" => 201);
-
-    header($_SERVER["SERVER_PROTOCOL"] . " 201 OK");
-
-    echo json_encode($result);
   }
 }

--- a/src/libraries/routes-api.php
+++ b/src/libraries/routes-api.php
@@ -43,6 +43,7 @@ $apiObj->post('/?v?[1-2]?/album/([a-zA-Z0-9]+)/(photo)/(add|remove).json', array
 $apiObj->get('/?v?[1-2]?/albums/list.json', array('ApiAlbumController', 'list_'), EpiApi::external); // retrieve activities (/albums/list.json)
 $apiObj->post('/?v?[1-2]?/album/([a-zA-Z0-9]+)/update.json', array('ApiAlbumController', 'update'), EpiApi::external); // update an album (/album/{id}/update.json)
 $apiObj->get('/?v?[1-2]?/album/([a-zA-Z0-9]+)/view.json', array('ApiAlbumController', 'view'), EpiApi::external); // retrieve activity (/activity/:id/view.json)
+$apiObj->get('/album/([a-zA-Z0-9]+)/ids.json', array('ApiAlbumController', 'listAlbumIds'), EpiApi::external); //retrieve photo ids (/albums/list.json) 
 
 /*
  * Manage endpoints

--- a/src/libraries/routes-api.php
+++ b/src/libraries/routes-api.php
@@ -43,7 +43,6 @@ $apiObj->post('/?v?[1-2]?/album/([a-zA-Z0-9]+)/(photo)/(add|remove).json', array
 $apiObj->get('/?v?[1-2]?/albums/list.json', array('ApiAlbumController', 'list_'), EpiApi::external); // retrieve activities (/albums/list.json)
 $apiObj->post('/?v?[1-2]?/album/([a-zA-Z0-9]+)/update.json', array('ApiAlbumController', 'update'), EpiApi::external); // update an album (/album/{id}/update.json)
 $apiObj->get('/?v?[1-2]?/album/([a-zA-Z0-9]+)/view.json', array('ApiAlbumController', 'view'), EpiApi::external); // retrieve activity (/activity/:id/view.json)
-$apiObj->get('/album/([a-zA-Z0-9]+)/ids.json', array('ApiAlbumController', 'listAlbumIds'), EpiApi::external); //retrieve photo ids (/albums/list.json) 
 
 /*
  * Manage endpoints
@@ -81,6 +80,7 @@ $apiObj->post('/?v?[1-2]?/photos/delete.json', array('ApiPhotoController', 'dele
 $apiObj->post('/?v?[1-2]?/photos/update.json', array('ApiPhotoController', 'updateBatch'), EpiApi::external); // update multiple photos (/photos/update.json)
 $apiObj->get('/?v?[1-2]?/photos/update.json', array('ApiPhotoController', 'updateBatchForm'), EpiApi::external); // update multiple photos (/photos/update.json)
 $apiObj->post('/?v?[1-2]?/photo/upload.json', array('ApiPhotoController', 'upload'), EpiApi::external); // upload a photo
+$routeObj->post('/photos/([a-zA-Z0-9,]+)/tarball', array('ApiPhotoController', 'createTarball'), EpiApi::external); // generate a tarball with the original images for the ids.
 $apiObj->post('/?v?[1-2]?/photos/upload/confirm.json', array('ApiPhotoController', 'uploadConfirm'), EpiApi::external); // confirmaton after upload
 $apiObj->get('/?v?[1-2]?/photo/([a-zA-Z0-9]+)/url/(\d+)x(\d+)x?([A-Zx]*)?.json', array('ApiPhotoController', 'dynamicUrl'), EpiApi::external); // generate a dynamic photo url (/photo/{id}/url/{options}.json) TODO, make internal for now
 $apiObj->get('/?v?[1-2]?/photo/([a-zA-Z0-9]+)/nextprevious/?(.+)?.json', array('ApiPhotoController', 'nextPrevious'), EpiApi::external); // get a photo's next/previous (/photo/{id}/nextprevious[/{options}].json)

--- a/src/libraries/routes.php
+++ b/src/libraries/routes.php
@@ -60,7 +60,6 @@ $routeObj->get('/photo/([a-zA-Z0-9-.]+)/tarball', array('PhotoController', 'getT
 $routeObj->get('/p/([a-zA-Z0-9]+)/?(.+)?', array('PhotoController', 'view')); // (shortcut for photo/view) view a photo (/p/{id}[/{options}])
 $routeObj->post('/photo/([a-zA-Z0-9]+)/update', array('PhotoController', 'update')); // update a photo (/photo/{id}/update
 $routeObj->post('/photo/upload', array('PhotoController', 'uploadPost')); // upload a photo
-$routeObj->post('/photos/tarball', array('PhotoController', 'createTarball')); // generate a tarball with the original images for the ids.
 $routeObj->get('/photos/upload', array('PhotoController', 'upload')); // view the upload photo form
 $routeObj->get('/photos/upload/beta', array('PhotoController', 'uploadBeta')); // upload a photo
 $routeObj->get('/photos/?(.+)?/list', array('PhotoController', 'list_')); // view all photos / optionally filter (/photos[/{options})]/list

--- a/src/libraries/routes.php
+++ b/src/libraries/routes.php
@@ -56,9 +56,11 @@ $routeObj->get('/photo/([a-zA-Z0-9]+)/edit', array('PhotoController', 'edit')); 
 $routeObj->get('/photo/([a-zA-Z0-9]+)/create/([a-z0-9]+)/([0-9]+)x([0-9]+)x?(.*).jpg', array('PhotoController', 'create')); // create a version of a photo (/photo/create/{id}/{options}.jpg)
 $routeObj->get('/photo/([a-zA-Z0-9]+)/?(token-[a-z0-9]+)?/download', array('PhotoController', 'download')); // download a high resolution version of a photo (/photo/create/{id}/{options}.jpg)
 $routeObj->get('/photo/([a-zA-Z0-9]+)/?(.+)?/view', array('PhotoController', 'view')); // view a photo (/photo/{id}[/{options}])/view
+$routeObj->get('/photo/([a-zA-Z0-9-.]+)/tarball', array('PhotoController', 'getTarball')); // serves the generated tarball
 $routeObj->get('/p/([a-zA-Z0-9]+)/?(.+)?', array('PhotoController', 'view')); // (shortcut for photo/view) view a photo (/p/{id}[/{options}])
 $routeObj->post('/photo/([a-zA-Z0-9]+)/update', array('PhotoController', 'update')); // update a photo (/photo/{id}/update
 $routeObj->post('/photo/upload', array('PhotoController', 'uploadPost')); // upload a photo
+$routeObj->post('/photos/tarball', array('PhotoController', 'createTarball')); // generate a tarball with the original images for the ids.
 $routeObj->get('/photos/upload', array('PhotoController', 'upload')); // view the upload photo form
 $routeObj->get('/photos/upload/beta', array('PhotoController', 'uploadBeta')); // upload a photo
 $routeObj->get('/photos/?(.+)?/list', array('PhotoController', 'list_')); // view all photos / optionally filter (/photos[/{options})]/list


### PR DESCRIPTION
Here is a first implementation proposal for a feature that let's you archive multiple photos. You can either download all photos in the batch queue or choose to download a complete album.

You can choose between zip and tar as output format. tar has a gzip and bzip2 option as well.

If you're in an album, the default name is the album's name.  If you're in the gallery, it's Images. 
I still need a good default name if you have photos from different albums in the queue.

![2014-04-19 15_56_41-trovebox user s photos - trovebox](https://cloud.githubusercontent.com/assets/4706166/2748669/f72f5c6a-c7ce-11e3-9a04-5fd59b986826.png)
![2014-04-19 15_57_03-trovebox user s photos - trovebox](https://cloud.githubusercontent.com/assets/4706166/2748670/f736e8cc-c7ce-11e3-90e4-4071b7430732.png)
![2014-04-19 15_57_44-trovebox user s photos - trovebox](https://cloud.githubusercontent.com/assets/4706166/2748671/f73deb72-c7ce-11e3-82d4-ed210a48393b.png)

Here is a [test openphoto instance](http://c5h8nnao4.dyndns.org/) with this branch as codebase for your convenience. Feel free to use it for testing pruposes. I'll keep the VirtualHost enabled at least until the PR get's merged.

You can sign in using thee following credentials without whitespaces

d u m m y @ t e s t . d e
d u m m y p a s s w o r d

---

This is my first time writing something in PHP so someone more experienced should probably look for beginners security flaws or accidental bad practices.

---

Todo:  
- Send the ids for the taball via post.
-  Fetch all ids for an album, not only the first 30.e
-  Don't block the server when generating a tarball

Notices:  
- The PharData class seems slower than executing tar or zip via `shell_exec` maybe there's a better alternative.  
