### PR TITLE
Cosmetic metadata fixes

### DIFF
--- a/src/html/assets/themes/fabrizio1.0/templates/partials/underscore.php
+++ b/src/html/assets/themes/fabrizio1.0/templates/partials/underscore.php
@@ -396,14 +396,14 @@
           <% } %>
           <% if( typeof exifFNumber !== 'undefined' && exifFNumber ){ %>
             <tr>
-              <th>F Number</th>
-              <td><%= exifFNumber %></td>
+              <th>Aperture</th>
+              <td>f/<%= exifFNumber %></td>
             </tr>
           <% } %>
           <% if( typeof exifFocalLength !== 'undefined' && exifFocalLength ){ %>
             <tr>
               <th>Focal Length</th>
-              <td><%= exifFocalLength %></td>
+              <td><%= exifFocalLength %>mm</td>
             </tr>
           <% } %>
           <% if( typeof exifISOSpeed !== 'undefined' && exifISOSpeed ){ %>


### PR DESCRIPTION
This is an obvious mistake. It clearly is not "ISO Time"
